### PR TITLE
Added best lap times to matchlog

### DIFF
--- a/plugins/helpers/challenge/challenge.php
+++ b/plugins/helpers/challenge/challenge.php
@@ -1,0 +1,5 @@
+<?php
+
+function getChallengeID($challengeInfo) {
+    return isset($challengeInfo['UId']) ? $challengeInfo['UId'] : 'UID';
+}

--- a/plugins/helpers/matchlog/Matchlog.php
+++ b/plugins/helpers/matchlog/Matchlog.php
@@ -1,0 +1,37 @@
+<?php
+require(dirname(__FILE__)."/../challenge/challenge.php");
+require_once "MatchlogTeams.php";
+require_once "MatchlogLaps.php";
+require_once "MatchlogRounds.php";
+require_once "MatchlogStunts.php";
+require_once "MatchlogTimeAttack.php";
+
+class Matchlog {
+
+    /**
+     * @param $logState - END_RACE, END_ROUND, BEGIN_ROUND
+     * @param $gameMode
+     * @param $challengeInfo
+     * @param $ranking
+     * @return void
+     */
+    static function create($logState, $gameMode, $challengeInfo, $ranking) {
+        switch($gameMode) {
+            case 0:
+            case 5: // Rounds
+                MatchlogRounds::create($logState, $challengeInfo, $ranking);
+                break;
+            case 1: // TimeAttack
+                MatchlogTimeAttack::create($logState, $challengeInfo, $ranking);
+                break;
+            case 2: // Teams
+                MatchlogTeams::create($logState, $challengeInfo, $ranking);
+                break;
+            case 3: // Laps
+                MatchlogLaps::create($logState, $challengeInfo);
+                break;
+            case 4: // Stunts
+                MatchlogStunts::create($logState, $challengeInfo, $ranking);
+        }
+    }
+}

--- a/plugins/helpers/matchlog/MatchlogLaps.php
+++ b/plugins/helpers/matchlog/MatchlogLaps.php
@@ -15,9 +15,8 @@ class MatchlogLaps {
         }
     }
 
-    private static function beginRound() {
+    private static function beginRound() {}
 
-    }
     private static function endRace($challengeInfo) {
         global $_players,$_PlayerList, $_NumberOfChecks,$_GameInfos,$_players_round_time,$_currentTime;
 
@@ -102,6 +101,7 @@ class MatchlogLaps {
         matchlog($matchlogMessage."\n\n");
         console("to matchlog: ".$matchlogMessage);
     }
+
     private static function getBestLapsAsString($bestLaps, $GameInfos) {
         $result = "\n* BestLaps\n";
         // the number of laps should be the maximum.
@@ -113,6 +113,7 @@ class MatchlogLaps {
 
         return $result;
     }
+
     private static function createFinishedPlayer($player) {
         return array(
             'Login'=>$player['Login'],
@@ -134,6 +135,7 @@ class MatchlogLaps {
 
         );
     }
+
     private static function getTimeHasFinished($lapsTimeLimit, $currentTime, $playersRoundTime, $lastTime) {
         if($lapsTimeLimit < 0) {
             return false;
@@ -164,10 +166,6 @@ class MatchlogLaps {
         }
 
         return $bestLapIndex;
-    }
-
-    private static function createChatMessage($finishedPlayers) {
-        $chatMessage = '$i$s$n$dfdRace$cc0>> ';
     }
 
     private static function getChatMessageForBestLap($player, $index) {
@@ -234,6 +232,7 @@ class MatchlogLaps {
         return $playerLapsPoints;
     }
 }
+
 function sortLaps($a, $b) {
     if($a['LapTimeMs']<$b['LapTimeMs'])
         return -1;

--- a/plugins/helpers/matchlog/MatchlogLaps.php
+++ b/plugins/helpers/matchlog/MatchlogLaps.php
@@ -96,7 +96,7 @@ class MatchlogLaps {
         $count = min(sizeof($bestLaps), $GameInfos['LapsNbLaps']);
         for($i = 0; $i < $count; $i++){
             $place = $i+1;
-                $result .= "\n".$place.", ".$bestLaps[$i]['LapTime'].", ".$bestLaps[$i]['Login'].", ".$bestLaps[$i]["NickName"];
+                $result .= $place.", ".$bestLaps[$i]['LapTime'].", ".$bestLaps[$i]['Login'].", ".$bestLaps[$i]["NickName"]."\n";
         }
 
         return $result;
@@ -152,7 +152,7 @@ class MatchlogLaps {
         }
 
     }
-    
+
     private static function getTextRowForPlayer($player, $firstFinishedPlayer, $index, $minCPdelay) {
         $text = "\n".($index+1).','.$player['Lap'].','.$player['Check'].','
             .MwTimeToString($player['Time']).','.MwTimeToString($player['BestLap']).','

--- a/plugins/helpers/matchlog/MatchlogLaps.php
+++ b/plugins/helpers/matchlog/MatchlogLaps.php
@@ -1,0 +1,269 @@
+<?php
+
+require_once "utils/MatchlogUtils.php";
+require_once "utils/MatchlogConsole.php";
+
+class MatchlogLaps {
+    static function create($logState, $challengeInfo) {
+        switch ($logState) {
+            case "END_RACE":
+                self::endRace($challengeInfo);
+                break;
+            case "BEGIN_ROUND":
+                self::beginRound();
+                break;
+        }
+    }
+
+    private static function beginRound() {
+
+    }
+    private static function endRace($challengeInfo) {
+        global $_players,$_PlayerList, $_NumberOfChecks,$_GameInfos,$_players_round_time,$_currentTime;
+
+        $numberOfCheckpoints = $_NumberOfChecks;
+        $players = $_players;
+        $playerList = $_PlayerList;
+        $currentTime = $_currentTime;
+        $gameInfo = $_GameInfos;
+        $playersRoundTime = $_players_round_time;
+
+        if($numberOfCheckpoints < 1) {
+            MatchlogConsole::consoleMatchlogEndRaceNoCheckpoints();
+            return;
+        }
+
+        // make table
+        $lastTime = 0;
+        $finishedPlayers = array();
+        $numberOfFinishers = 0;
+        $minCPdelay = 99999;
+        $lapsArr = array();
+
+        foreach($players as $login => &$player){
+            if($player['CheckpointNumber'] > 0 && $player['LastCpTime'] > 0 && $player['LapNumber'] >= 0){
+                if($player['FinalTime'] > 0) {
+                    $numberOfFinishers++;
+                }
+
+                $finishedPlayers[] = self::createFinishedPlayer($player);
+                foreach($player['Laps'] as $key => $lapTime) {
+                    $lapsArr[] = self::createLapItem($player, $lapTime);
+                }
+
+                if($player['LastCpTime'] > $lastTime) {
+                    $lastTime = $player['LastCpTime'];
+                }
+
+            }else{
+                MatchlogConsole::consoleMatchlogEndRace($player);
+            }
+
+            if($player['CPdelay'] > 0 && $player['CPdelay'] < $minCPdelay) {
+                $minCPdelay = $player['CPdelay'];
+            }
+
+        }
+
+        $timeHasFinished = self::getTimeHasFinished($gameInfo['LapsTimeLimit'], $currentTime, $playersRoundTime, $lastTime);
+
+        if(!(count($finishedPlayers) > 0 && ($numberOfFinishers > 0 || $timeHasFinished))) {
+            MatchlogConsole::consoleMatchlogEndRaceNoFinishedPlayers();
+            return;
+        }
+
+        // sort all laps, the best ones first.
+        usort($lapsArr, 'sortLaps');
+
+        // sort laps finishedPlayers, then make log and message
+        usort($finishedPlayers,'matchlogRecCompareLaps');
+
+        // search player with the best lap
+        $bestLapIndex = self::findIndexOfBestLap($finishedPlayers);
+
+        $chatMessage = '$i$s$n$dfdRace$cc0>> ';
+        $matchlogMessage = MatchlogUtils::getMatchlogTitle($challengeInfo, 'LAPS');
+
+        for($i = 0; $i < sizeof($finishedPlayers); $i++){
+            $currentPlayer = $finishedPlayers[$i];
+            $matchlogMessage .= self::getTextRowForPlayer($currentPlayer, $finishedPlayers[0], $i, $minCPdelay);
+
+            if($i==$bestLapIndex){
+                $chatMessage .= self::getChatMessageForBestLap($currentPlayer, $i);
+            }else{
+                $chatMessage .= self::getChatMessageForRegularLap($currentPlayer, $i);
+            }
+        }
+
+        $matchlogMessage .= MatchlogUtils::getTextSpectators($playerList);
+        $matchlogMessage .= self::getBestLapsAsString($lapsArr, $gameInfo);
+
+        addCall(null,'ChatSendServerMessage', $chatMessage);
+        matchlog($matchlogMessage."\n\n");
+        console("to matchlog: ".$matchlogMessage);
+    }
+    private static function getBestLapsAsString($bestLaps, $GameInfos) {
+        $result = "\n* BestLaps\n";
+        // the number of laps should be the maximum.
+        $count = min(sizeof($bestLaps), $GameInfos['LapsNbLaps']);
+        for($i = 0; $i < $count; $i++){
+            $place = $i+1;
+            $result .= $place.",".$bestLaps[$i]['LapTime'].",".$bestLaps[$i]['Login'].",".$bestLaps[$i]['NickName']."\n";
+        }
+
+        return $result;
+    }
+    private static function createFinishedPlayer($player) {
+        return array(
+            'Login'=>$player['Login'],
+            'NickName'=>$player['NickName'],
+            'Check'=>$player['CheckpointNumber']+1,
+            'Lap'=>$player['LapNumber'],
+            'Time'=>$player['LastCpTime'],
+            'BestLap'=>$player['BestLapTime'],
+            'CPdelay'=>$player['CPdelay']
+        );
+    }
+
+    private static function createLapItem($player, $lapTime) {
+        return array(
+            'Login' => $player['Login'],
+            'NickName' => stripColors($player['NickName']),
+            'LapTimeMs' => $lapTime,
+            'LapTime' => MwTimeToString($lapTime),
+
+        );
+    }
+    private static function getTimeHasFinished($lapsTimeLimit, $currentTime, $playersRoundTime, $lastTime) {
+        if($lapsTimeLimit < 0) {
+            return false;
+        }
+
+        if(($currentTime - $playersRoundTime) > $lapsTimeLimit){
+            console("matchlogEndRace::Laps race finished by timelimit (race time)");
+            return true;
+        }
+
+        if($lastTime + 10000 > $lapsTimeLimit){
+            console("matchlogEndRace::Laps race finished by timelimit (player time)");
+            return true;
+        }
+
+    }
+
+
+    private static function findIndexOfBestLap($finishedPlayers) {
+        // search bestlap player
+        $bestLapIndex = 0;
+        for($i = 0; $i < sizeof($finishedPlayers); $i++){
+            if($finishedPlayers[$i]['BestLap']>0){
+                if($finishedPlayers[$bestLapIndex]['BestLap']<=0 || $finishedPlayers[$bestLapIndex]['BestLap']>$finishedPlayers[$i]['BestLap']) {
+                    $bestLapIndex = $i;
+                }
+            }
+        }
+
+        return $bestLapIndex;
+    }
+
+    private static function createChatMessage($finishedPlayers) {
+        $chatMessage = '$i$s$n$dfdRace$cc0>> ';
+    }
+
+    private static function getChatMessageForBestLap($player, $index) {
+        return ''.'$0f0 '.($index+1).'.$ecc'.stripColors($player['NickName'])
+            .' $aaa('.$player['Check'].','.MwTimeToString($player['Time'])
+            .',$ecc'.MwTimeToString($player['BestLap']).'$aaa)';
+
+    }
+
+    private static function getChatMessageForRegularLap($player, $index) {
+        return ''.'$0f0 '.($index+1).'.$ddd'.stripColors($player['NickName'])
+            .' $aaa('.$player['Check'].','.MwTimeToString($player['Time']).')';
+    }
+
+    private static function getTextRowForPlayer($player, $firstFinishedPlayer, $index, $minCPdelay) {
+        $text = "\n".($index+1).','.$player['Lap'].','.$player['Check'].','
+            .MwTimeToString($player['Time']).','.MwTimeToString($player['BestLap']).','
+            .(($player['CPdelay']-$minCPdelay)/1000).',';
+
+        return $text.''.self::getPointsForPlayer($player, $firstFinishedPlayer, $index).','.stripColors($player['Login']).','.stripColors($player['NickName']);
+    }
+
+    private static function getPointsForPlayer($player, $firstFinishedPlayer, $index) {
+        global $_lapspoints_notfinishmultiplier, $_lapspoints_rule, $_lapspoints_points, $_lapspoints_finishbonus;
+
+        $lapsPointsRule = $_lapspoints_rule;
+        $lapsPoints = $_lapspoints_points;
+        $lapsPointsFinishBonus = $_lapspoints_finishbonus;
+        $lapsPointsNotFinishMultiplier = $_lapspoints_notfinishmultiplier;
+        $playerLapsPoints = 0;
+
+        // main points
+        if(isset($lapsPoints[$lapsPointsRule][$index])) {
+            $playerLapsPoints += $lapsPoints[$lapsPointsRule][$index];
+        } else {
+            $playerLapsPoints += end($lapsPoints[$lapsPointsRule]);
+        }
+
+
+        if($player['Check'] >= $firstFinishedPlayer['Check']){
+            // add finish bonus
+            if(isset($lapsPointsFinishBonus[$lapsPointsRule]) && isset($lapsPointsFinishBonus[$lapsPointsRule][100])) {
+                $playerLapsPoints += $lapsPointsFinishBonus[$lapsPointsRule][100];
+            }
+
+        }else{
+            // not finished
+            if(isset($lapsPointsNotFinishMultiplier[$lapsPointsRule])){
+                // not finished multiplier
+                $playerLapsPoints = (int) ceil($playerLapsPoints * $_lapspoints_notfinishmultiplier[$lapsPointsRule]);
+
+            }elseif(isset($lapsPointsFinishBonus[$lapsPointsRule])){
+                // or else partial race % bonuses
+                $partial = (int) floor($player['Check'] * 100 / $firstFinishedPlayer['Check']);
+                foreach($lapsPointsFinishBonus[$lapsPointsRule] as $val => $bonus){
+                    if($partial >= $val){
+                        $playerLapsPoints += $bonus;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $playerLapsPoints;
+    }
+}
+function sortLaps($a, $b) {
+    if($a['LapTimeMs']<$b['LapTimeMs'])
+        return -1;
+    elseif($a['LapTimeMs']>$b['LapTimeMs'])
+        return 1;
+}
+
+// -----------------------------------
+// compare function for usort, return -1 if $a should be before $b
+function matchlogRecCompareLaps($a, $b)
+{
+    if($a['Check']>$b['Check'])
+        return -1;
+    elseif($a['Check']<$b['Check'])
+        return 1;
+    // same number of check, test times
+    elseif($a['Time']<$b['Time'])
+        return -1;
+    elseif($a['Time']>$b['Time'])
+        return 1;
+    // same times, test bestlap times
+    elseif($a['BestLap']<=0 && $b['BestLap']<=0)
+        return -1;
+    elseif($b['BestLap']<=0)
+        return -1;
+    elseif($a['BestLap']<=0)
+        return 1;
+    elseif($a['BestLap']<$b['BestLap'])
+        return -1;
+    elseif($a['BestLap']>$b['BestLap'])
+        return 1;
+    return -1;
+}

--- a/plugins/helpers/matchlog/MatchlogRounds.php
+++ b/plugins/helpers/matchlog/MatchlogRounds.php
@@ -31,13 +31,13 @@ class MatchlogRounds {
     private static function endRace($challengeInfo, $ranking) {
         global $_players_round_current, $_PlayerList, $_players;
 
-        $matchlogMessage = getMatchlogTitle($challengeInfo, 'ROUNDS',  '['.$_players_round_current.'r]');
+        $matchlogMessage = MatchlogUtils::getMatchlogTitle($challengeInfo, 'ROUNDS',  '['.$_players_round_current.'r]');
 
         for($i = 0; $i < sizeof($ranking); $i++){
             $matchlogMessage .= "\n".$ranking[$i]['Rank'].','.$ranking[$i]['Score'].','.MwTimeToString($ranking[$i]['BestTime']).','.stripColors($ranking[$i]['Login']).','.stripColors($ranking[$i]['NickName']);
         }
 
-        $matchlogMessage .= getTextSpectators($_PlayerList);
+        $matchlogMessage .= MatchlogUtils::getTextSpectators($_PlayerList);
 
         $sep = "\n* Results: "; // pos in each round
         foreach($_players as $login => &$pl){

--- a/plugins/helpers/matchlog/MatchlogRounds.php
+++ b/plugins/helpers/matchlog/MatchlogRounds.php
@@ -1,0 +1,67 @@
+<?php
+
+require_once(dirname(__FILE__)."/../utils/stringUtils.php");
+require_once "utils/MatchlogUtils.php";
+
+class MatchlogRounds {
+    static function create($logState, $challengeInfo, $ranking) {
+        switch ($logState) {
+            case "END_RACE":
+                self::endRace($challengeInfo, $ranking);
+                break;
+            case "BEGIN_ROUND":
+                self::beginRound();
+                break;
+            case "END_ROUND":
+                MatchlogUtils::endRound();
+                break;
+        }
+    }
+
+    private static function beginRound() {
+
+    }
+
+    /**
+     * @param $challengeInfo
+     * @param $ranking
+     * @param $playerList
+     * @return void
+     */
+    private static function endRace($challengeInfo, $ranking) {
+        global $_players_round_current, $_PlayerList, $_players;
+
+        $matchlogMessage = getMatchlogTitle($challengeInfo, 'ROUNDS',  '['.$_players_round_current.'r]');
+
+        for($i = 0; $i < sizeof($ranking); $i++){
+            $matchlogMessage .= "\n".$ranking[$i]['Rank'].','.$ranking[$i]['Score'].','.MwTimeToString($ranking[$i]['BestTime']).','.stripColors($ranking[$i]['Login']).','.stripColors($ranking[$i]['NickName']);
+        }
+
+        $matchlogMessage .= getTextSpectators($_PlayerList);
+
+        $sep = "\n* Results: "; // pos in each round
+        foreach($_players as $login => &$pl){
+            $login = toString($login);
+            if(count($pl['RoundsPos'])>0){
+                $rend = endkey($pl['RoundsPos']);
+                if($rend < $_players_round_current) {
+                    $rend = $_players_round_current;
+                }
+
+                $matchlogMessage .= $sep.$login.'(';
+                $sep2 = '';
+                for($rnum=1; $rnum<=$rend; $rnum++){
+                    if(isset($pl['RoundsPos'][$rnum]))
+                        $matchlogMessage .= $sep2.$pl['RoundsPos'][$rnum];
+                    else
+                        $matchlogMessage .= $sep2.'*';
+                    $sep2 = ',';
+                }
+                $matchlogMessage .= ')';
+                $sep = ', ';
+            }
+        }
+        matchlog($matchlogMessage."\n\n");
+    }
+}
+

--- a/plugins/helpers/matchlog/MatchlogStunts.php
+++ b/plugins/helpers/matchlog/MatchlogStunts.php
@@ -19,13 +19,13 @@ class MatchlogStunts {
      */
     private static function endRace($challengeInfo, $ranking) {
         global $_PlayerList;
-        $matchlogMessage = getMatchlogTitle($challengeInfo, 'STUNTS');
+        $matchlogMessage = MatchlogUtils::getMatchlogTitle($challengeInfo, 'STUNTS');
 
         for($i = 0; $i < sizeof($ranking); $i++){
             $matchlogMessage .= "\n".$ranking[$i]['Rank'].','.$ranking[$i]['Score'].','.stripColors($ranking[$i]['Login']).','.stripColors($ranking[$i]['NickName']);
         }
 
-        $matchlogMessage .= getTextSpectators($_PlayerList);
+        $matchlogMessage .= MatchlogUtils::getTextSpectators($_PlayerList);
         matchlog($matchlogMessage."\n\n");
     }
 }

--- a/plugins/helpers/matchlog/MatchlogStunts.php
+++ b/plugins/helpers/matchlog/MatchlogStunts.php
@@ -1,0 +1,31 @@
+<?php
+
+require_once "utils/MatchlogUtils.php";
+
+class MatchlogStunts {
+    static function create($logState, $challengeInfo, $ranking) {
+        switch ($logState) {
+            case "END_RACE":
+                self::endRace($challengeInfo, $ranking);
+                break;
+        }
+    }
+
+    /**
+     * @param $challengeInfo
+     * @param $ranking
+     * @param $playerList
+     * @return void
+     */
+    private static function endRace($challengeInfo, $ranking) {
+        global $_PlayerList;
+        $matchlogMessage = getMatchlogTitle($challengeInfo, 'STUNTS');
+
+        for($i = 0; $i < sizeof($ranking); $i++){
+            $matchlogMessage .= "\n".$ranking[$i]['Rank'].','.$ranking[$i]['Score'].','.stripColors($ranking[$i]['Login']).','.stripColors($ranking[$i]['NickName']);
+        }
+
+        $matchlogMessage .= getTextSpectators($_PlayerList);
+        matchlog($matchlogMessage."\n\n");
+    }
+}

--- a/plugins/helpers/matchlog/MatchlogTeams.php
+++ b/plugins/helpers/matchlog/MatchlogTeams.php
@@ -1,0 +1,181 @@
+<?php
+
+require_once "utils/MatchlogUtils.php";
+
+require_once(dirname(__FILE__)."/../utils/stringUtils.php");
+
+class MatchlogTeams {
+    static function create($logState, $challengeInfo, $ranking) {
+        switch ($logState) {
+            case "END_RACE":
+                MatchlogTeams::endRace($challengeInfo, $ranking);
+                break;
+            case "BEGIN_ROUND":
+                MatchlogTeams::beginRound();
+                break;
+            case "END_ROUND":
+                MatchlogUtils::endRound();
+                break;
+        }
+    }
+
+    /**
+     * @param $challengeInfo
+     * @param $ranking
+     * @param $playerList
+     * @return void
+     */
+    static function endRace($challengeInfo, $ranking) {
+        global $_PlayerList, $_players, $_players_round_current;
+
+        // add the last team score line before starting the final score match log
+        matchlog(self::getTextTeamScores($ranking, 'Score'));
+
+        //[11/21,22:02:04] TEAM MATCH on [ULR6 -  Scrape it] (Bay,xCuDJWONR8ojVmRfVPUkD5dX9u6,djcomixxx) [14r]
+        $matchlogMessage2 = MatchlogUtils::getMatchlogTitle($challengeInfo, 'TEAM', ' ['.$_players_round_current.'r]');
+
+        // Final Score: $00FBlue Team 6 <> 8 $F00Red Team
+        $matchlogMessage2 .= self::getTextTeamScores($ranking, '\nFinal Score: ');
+
+        // * Blue players: jonny666777[[TnT]jonny], bo.omz0r[tnt.passi], rudi0800[TnT.Norman]
+        $matchlogMessage2 .= self::getTextTeamLineUp($_PlayerList, 'Blue');
+
+        // * Red players: zickman13[rev.nekoツ], zepset[rev. Ζєрѕєт], chris_ri[rev.Luffy]
+        $matchlogMessage2 .= self::getTextTeamLineUp($_PlayerList, 'Red');
+
+        // These are not used very often I think. could be removed?
+        $matchlogMessage2 .= MatchlogUtils::getTextSpectators($_PlayerList);
+        $matchlogMessage2 .= self::getTextAllPlayers($_PlayerList);
+
+        // * Results: jonny666777(3,3,5,2,6,4,3,5,2,3,5,2,2,4), bo.omz0r(1,1,1,5,1,1,5,2,4,5,1,3,5,1), zickman13(2,4,6,3,2,2,6,4,1,4,3,1,1,3),
+        // zepset(4,2,3,1,3,3,1,1,3,1,2,6,4,2), chris_ri(5,6,4,4,4,5,4,6,6,2,4,5,3,5), rudi0800(6,5,2,6,5,6,2,3,5,6,6,4,6,6)
+        $matchlogMessage2 .= self::getTextPlayerRoundPositionResults($_players);
+
+        matchlog($matchlogMessage2."\n\n");
+    }
+
+    private static function beginRound() {
+        global $_Status, $_Ranking, $_matchlog_Ranking, $_teamcolor;
+
+        if ($_Status['Code'] >= 3) {
+            // the score has changed
+            if($_Ranking[0]['Score'] != $_matchlog_Ranking[0]['Score'] || $_Ranking[1]['Score'] != $_matchlog_Ranking[1]['Score']){
+                $tnick0 = stripColors(''.$_Ranking[0]['NickName']);
+                $tnick1 = stripColors(''.$_Ranking[1]['NickName']);
+
+                $msg = '$z $ddd* Score: '.$_teamcolor[0].getTeamName($_Ranking[0]).' '.$_Ranking[0]['Score'];
+                $msg .= '$ddd <> '.$_teamcolor[1].$_Ranking[1]['Score'].' '.getTeamName($_Ranking[1]).'$z';
+
+                addCall(null,'ChatSendServerMessage', $msg);
+                console('Score - '.stripColors($msg));
+
+                matchlog(getTextTeamScores($_Ranking, 'Score'));
+            }
+        }
+
+        $_matchlog_Ranking = $_Ranking;
+
+    }
+
+    private static function endRound() {
+
+    }
+
+
+    private static function getTeamName($rankingItem){
+        return ''.stripColors(''.$rankingItem['NickName']);
+    }
+
+    /**
+     * @param $ranking
+     * @param $prefix
+     * @return string - example: Score: Blue Team 6 <> 7 Red Team
+     */
+    private static function getTextTeamScores($ranking, $prefix) {
+        $teamName0 = self::getTeamName($ranking[0]);
+        $teamName1 = self::getTeamName($ranking[1]);;
+        return $prefix .': '.$teamName0.' '.$ranking[0]['Score'].' <> '.$ranking[1]['Score'].' '.$teamName1."\n";
+    }
+
+
+
+    /**
+     * @param $player
+     * @return string - example: ruso001[DND.Sonic]
+     */
+    private static function getPlayerLoginAndName($player) {
+        return stripColors($player['Login']).'['.stripColors($player['NickName']).']';
+    }
+
+    /**
+     * @param $playerList
+     * @param $teamColor
+     * @return string - Example: jasper1[[DND.Jasper], beez02[DND.Beez], ruso001[DND.Sonic]
+     */
+    private static function getTextTeamLineUp($playerList, $teamColor) {
+        $result = "";
+        $sep = "\n* {$teamColor} players: ";
+        for($i = 0; $i < sizeof($playerList); $i++){
+            if(isset($playerList[$i]['TeamId']) && ($playerList[$i]['TeamId']==1)){
+                $result .= $sep.self::getPlayerLoginAndName($playerList[$i]);
+                $sep = ', ';
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Backup function, if server doesn't give player team info
+     * @param $playerList
+     * @return string - Example: jasper1[[DND.Jasper], beez02[DND.Beez], ruso001[DND.Sonic]
+     */
+    private static function getTextAllPlayers($playerList) {
+        $result = "";
+        $sep = "\n* All players: ";  // server don't give player team info
+        for($i = 0; $i < sizeof($playerList); $i++){
+            if(!isset($playerList[$i]['TeamId'])){
+                $result .= $sep.self::getPlayerLoginAndName($playerList[$i]);
+                $sep = ', ';
+            }
+        }
+
+        return $result;
+    }
+
+    private static function getTextPlayerRoundPositionResults($players) {
+        global $_players_round_current;
+
+        $result = "";
+        $sep = "\n* Results: "; // pos in each round
+
+        foreach($players as $login => &$player){
+            if(count($player['RoundsPos']) <= 0){
+                continue;
+            }
+
+            $rend = endkey($player['RoundsPos']);
+            if($rend < $_players_round_current) {
+                $rend = $_players_round_current;
+            }
+
+            $result .= $sep.toString($login).'(';
+            $sep2 = '';
+
+            for($rnum=1; $rnum<=$rend; $rnum++){
+                if(isset($player['RoundsPos'][$rnum])) {
+                    $result .= $sep2.$player['RoundsPos'][$rnum];
+                } else {
+                    $result .= $sep2.'*';
+                }
+                $sep2 = ',';
+            }
+            $result .= ')';
+            $sep = ', ';
+        }
+
+        return $result;
+    }
+}
+
+

--- a/plugins/helpers/matchlog/MatchlogTeams.php
+++ b/plugins/helpers/matchlog/MatchlogTeams.php
@@ -77,10 +77,7 @@ class MatchlogTeams {
 
     }
 
-    private static function endRound() {
-
-    }
-
+    private static function endRound() {}
 
     private static function getTeamName($rankingItem){
         return ''.stripColors(''.$rankingItem['NickName']);

--- a/plugins/helpers/matchlog/MatchlogTimeAttack.php
+++ b/plugins/helpers/matchlog/MatchlogTimeAttack.php
@@ -1,0 +1,33 @@
+<?php
+
+require_once "utils/MatchlogUtils.php";
+
+class MatchlogTimeAttack {
+    static function create($logState, $challengeInfo, $ranking) {
+        switch ($logState) {
+            case "END_RACE":
+                self::endRace($challengeInfo, $ranking);
+                break;
+        }
+    }
+
+    /**
+     * @param $challengeInfo
+     * @param $ranking
+     * @param $playerList
+     * @return void
+     */
+    private static function endRace($challengeInfo, $ranking) {
+        global $_PlayerList;
+
+        $matchlogMessage = MatchlogUtils::getMatchlogTitle($challengeInfo, 'TIMEATTACK');
+        for($i = 0; $i < sizeof($ranking); $i++){
+            $matchlogMessage .= "\n".$ranking[$i]['Rank'].','.MwTimeToString($ranking[$i]['BestTime']).','.stripColors($ranking[$i]['Login']).','.stripColors($ranking[$i]['NickName']);
+        }
+
+        $matchlogMessage .= MatchlogUtils::getTextSpectators($_PlayerList);
+
+        matchlog($matchlogMessage."\n\n");
+    }
+}
+

--- a/plugins/helpers/matchlog/utils/MatchlogConsole.php
+++ b/plugins/helpers/matchlog/utils/MatchlogConsole.php
@@ -1,0 +1,30 @@
+<?php
+
+class MatchlogConsole {
+    static function consoleMatchlogEndRace($player) {
+        global $_debug;
+
+        if($_debug>1) {
+            // Player did not end the race
+            console("matchlogEndRace:: skipped: {$player['Login']},{$player['Active']},{$player['CheckpointNumber']},
+                {$player['Score']},{$player['LapNumber']},{$player['LastCpTime']},{$player['BestLapTime']}");
+        }
+    }
+
+    static function consoleMatchlogEndRaceNoFinishedPlayers() {
+        global $_debug;
+
+        if($_debug>1) {
+            console("matchlogEndRace:: Not sent to matchlog:  no finishedPlayers or none have finished !!!");
+        }
+    }
+
+    static function consoleMatchlogEndRaceNoCheckpoints() {
+        global $_debug;
+
+        if($_debug>1) {
+            console("matchlogEndRace:: Not sent to matchlog: _NumberOfChecks=0 !!!");
+        }
+    }
+}
+

--- a/plugins/helpers/matchlog/utils/MatchlogUtils.php
+++ b/plugins/helpers/matchlog/utils/MatchlogUtils.php
@@ -1,0 +1,106 @@
+<?php
+require_once(dirname(__FILE__)."/../../challenge/challenge.php");
+
+
+class MatchlogUtils {
+    /**
+     * @param $challengeInfo - The Challenge info
+     * @param $prefix - TIMEATTACK, ROUNDS, LAPS, TEAMLAPS, STUNTS
+     * @return string - The title
+     */
+    static function getMatchlogTitle($challengeInfo, $prefix, $suffix = "") {
+        $cuid = getChallengeID($challengeInfo);
+        return $prefix.' MATCH on ['.stripColors($challengeInfo['Name']).'] ('.$challengeInfo['Environnement'].',' .$cuid.','.stripColors($challengeInfo['Author']).')'.$suffix;
+    }
+
+    static function getTextSpectators($playersList) {
+        $text = "";
+        $separator = "\n* Spectators: ";
+        for($i = 0; $i < sizeof($playersList); $i++){
+            if(isset($playersList[$i]['IsSpectator']) && ($playersList[$i]['IsSpectator'] == 1)){
+                $text .= $separator.stripColors($playersList[$i]['Login']).'['.stripColors($playersList[$i]['NickName']).']';
+                $separator = ', ';
+            }
+        }
+
+        return $text;
+    }
+
+    static function endRound() {
+        global $_GameInfos, $_debug, $_players_round_current, $_teams;
+
+        $times = self::getPlayerTimes();
+
+        if($_debug>1) debugPrint('matchlogEndRound - times',$times);
+
+        if(count($times) <= 0) {
+            return;
+        }
+
+        usort($times,'matchlogRecCompare');
+
+        $msg2 = 'Round-'.$_players_round_current;
+        $sep2 = ':';
+
+        for($i=0; $i<count($times); $i++) {
+            if($i===0) {
+                if($_GameInfos['GameMode']==2) {
+                    $msg2 .= '(B='.$_teams[0]['Score'].',R='.$_teams[1]['Score'].')';
+                } else {
+                    $msg2 .= '('.MwTimeToString($times[$i]['FinalTime']).')';
+                }
+            }
+
+            $msg2 .= $sep2.stripColors($times[$i]['NickName']);
+            $sep2 = ',';
+        }
+
+        $sep2 = "\nTimes: ";
+        for($i=0;$i<count($times)&&$i<10;$i++){
+            $msg2 .= $sep2.stripColors($times[$i]['Login']).'('.MwTimeToString($times[$i]['FinalTime']).')';
+            $sep2 = ', ';
+        }
+
+        matchlog($msg2);
+        // don't show in chat for TMU dedicated (visible in manialinks)
+        //addCall(null,'ChatSendServerMessage', $msg);
+    }
+
+
+    private static function getPlayerTimes() {
+        global $_players;
+
+        $times = array();
+        foreach($_players as $login => &$player){
+            if($player['FinalTime']>0){
+
+                $times[] = array('Login'=>$player['Login'],
+                    'NickName'=>$player['NickName'],
+                    'FinalTime'=>$player['FinalTime'],
+                    'TeamId'=>$player['TeamId']);
+            }
+        }
+
+        return $times;
+    }
+
+}
+
+// -----------------------------------
+// compare function for usort, return -1 if $a should be before $b
+function matchlogRecCompare($a, $b){
+    if($a['FinalTime']<=0 && $b['FinalTime']<=0)
+        return strcmp($a['NickName'],$b['NickName']);
+    elseif($b['FinalTime']<=0)
+        return -1;
+    elseif($a['FinalTime']<=0)
+        return 1;
+
+    // both best ok, so...
+    elseif($a['FinalTime']<$b['FinalTime'])
+        return -1;
+    elseif($a['FinalTime']>$b['FinalTime'])
+        return 1;
+    return -1;
+}
+

--- a/plugins/helpers/utils/stringUtils.php
+++ b/plugins/helpers/utils/stringUtils.php
@@ -1,0 +1,5 @@
+<?php
+
+function toString($var) {
+    return !is_string($var) ? ''.$var : $var;
+}

--- a/plugins/plugin.26.matchlog.php
+++ b/plugins/plugin.26.matchlog.php
@@ -1,4 +1,9 @@
 <?php
+	//require (dirname(__FILE__)."\..\helpers\matchlog\matchlogLaps.php");
+
+
+require_once "helpers/matchlog/Matchlog.php";
+
 ////////////////////////////////////////////////////////////////
 //¤
 // File:      FAST 3.2 (First Automatic Server for Trackmania)
@@ -23,13 +28,14 @@ $do_match_log = true;
 // Init :
 //--------------------------------------------------------------
 function matchlogInit(){
-	global $_debug,$do_match_log,$matchfilename,$htmlmatchfilename,$matchfile,$_Game,$_DedConfig,$_lapspoints_points,$_lapspoints_finishbonus,$_lapspoints_notfinishmultiplier,$_lapspoints_rule;
+	global $do_match_log,$matchfilename,$htmlmatchfilename,$matchfile,$_Game,$_DedConfig,$_lapspoints_points,$_lapspoints_finishbonus,$_lapspoints_notfinishmultiplier,$_lapspoints_rule;
 
 	$matchfilename = "fastlog/matchlog.".strtolower($_Game).".".$_DedConfig['login'].".txt";
 	$htmlmatchfilename = "matchlog.".strtolower($_Game).".".$_DedConfig['login'].".html";
 
-	if(!isset($_lapspoints_rule))
+	if(!isset($_lapspoints_rule)) {
 		$_lapspoints_rule = 'fet3';
+	}
 
 	$_lapspoints_points['fet2'] = array(15,12,11,10,9,8,7,6,6,5,5,4,4,3,3,3,2,2,2,2,1,1,0);
 	$_lapspoints_finishbonus['fet2'] = array(100=>5,80=>4,60=>3,40=>2,20=>1); // if >= index% of race, then add indicated bonus, must be in decreasing order !!
@@ -42,8 +48,10 @@ function matchlogInit(){
 	// open log file
 	if($do_match_log){
 		$matchfile = fopen($matchfilename,"ab");
-		if($matchfile === false)
+		if($matchfile === false) {
 			$do_match_log = false;
+		}
+
 	}
 }
 
@@ -52,14 +60,16 @@ function matchlogInit(){
 // BeginRace :
 //--------------------------------------------------------------
 function matchlogBeginRace($event,$GameInfos){
-	global $_debug,$_matchlog_Ranking,$do_match_log,$matchfile,$matchfilename;
+	global $_matchlog_Ranking,$do_match_log,$matchfile,$matchfilename;
 	$_matchlog_Ranking[0]['Score'] = -1;
 	$_matchlog_Ranking[1]['Score'] = -1;
 
 	// re-open log file (sometimes usefull if the file was modified externally after fast init)
 	if($do_match_log){
-		if($matchfile !== false)
+		if($matchfile !== false) {
 			@fclose($matchfile);
+		}
+
 		$matchfile = fopen($matchfilename,'ab');
 	}
 }
@@ -69,30 +79,12 @@ function matchlogBeginRace($event,$GameInfos){
 // BeginRound :
 //------------------------------------------
 function matchlogBeginRound(){
-	global $_debug,$_PlayerList,$_Ranking,$_matchlog_Ranking,$_GameInfos,$_Status,$_team_color,$_teamcolor,$do_match_log,$_WarmUp,$_FWarmUp;
-	if(!$do_match_log || $_WarmUp || $_FWarmUp > 0)
+	global $_Ranking,$_GameInfos;
+	if(isMatchlogDisabled()) {
 		return;
-
-	if ($_GameInfos['GameMode'] == 2){ // team
-		if ($_Status['Code']>=3){
-
-			// the score has changed
-			if($_Ranking[0]['Score']!=$_matchlog_Ranking[0]['Score'] || $_Ranking[1]['Score']!=$_matchlog_Ranking[1]['Score']){
-				$tnick0 = stripColors(''.$_Ranking[0]['NickName']);
-				$tnick1 = stripColors(''.$_Ranking[1]['NickName']);
-
-				$msg = '$z $ddd* Score: '.$_teamcolor[0].$tnick0.' '.$_Ranking[0]['Score'];
-				$msg .= '$ddd <> '.$_teamcolor[1].$_Ranking[1]['Score'].' '.$tnick1.'$z';
-
-				addCall(null,'ChatSendServerMessage', $msg);
-				console('Score - '.stripColors($msg));
-				$msg = 'Score: '.$tnick0.' '.$_Ranking[0]['Score'].' <> '.$_Ranking[1]['Score'].' '.$tnick1."\n";
-				matchlog($msg);
-			}
-		}
-		$_matchlog_Ranking = $_Ranking;
 	}
 
+	Matchlog::create("BEGIN_ROUND", $_GameInfos['GameMode'], null, $_Ranking);
 }
 
 
@@ -100,377 +92,30 @@ function matchlogBeginRound(){
 // EndRound :
 //------------------------------------------
 function matchlogEndRound($event,$Ranking,$ChallengeInfo,$GameInfos,$SpecialRestarting){
-	global $_debug,$_players,$_GameInfos,$_team_color,$do_match_log,$_players_round_current,$_Game,$_teams,$_WarmUp,$_FWarmUp,$_FGameModes,$_FGameMode;
-	if($SpecialRestarting || !$do_match_log || $_WarmUp || $_FWarmUp > 0)
+	if($SpecialRestarting || isMatchlogDisabled() || hasFGameMode("MatchLogEndRound",$event,$Ranking,$ChallengeInfo,$GameInfos, $SpecialRestarting)){
 		return;
-
-	if(isset($_FGameModes[$_FGameMode]['MatchLogEndRound']) && $_FGameModes[$_FGameMode]['MatchLogEndRound'] != '' &&
-		 function_exists($_FGameModes[$_FGameMode]['MatchLogEndRound'])){
-		// call FGameMode matchlog callback if exists
-		call_user_func($_FGameModes[$_FGameMode]['MatchLogEndRound'],$event,$Ranking,$ChallengeInfo,$GameInfos,$SpecialRestarting);
-
-	}elseif($_GameInfos['GameMode'] == 2 || $_GameInfos['GameMode'] == 0 || $_GameInfos['GameMode'] == 5){ // team or rounds or cup
-		$times = array();
-		foreach($_players as $login => &$pl){
-			if(!is_string($login))
-				$login = ''.$login;
-			if($pl['FinalTime']>0){
-				//debugPrint('matchlogEndRound - players[$login]',$_players[$login]);
-				$times[] = array('Login'=>$pl['Login'],
-												 'NickName'=>$pl['NickName'],
-												 'FinalTime'=>$pl['FinalTime'],
-												 'TeamId'=>$pl['TeamId']);
-			}
-		}
-		if($_debug>1) debugPrint('matchlogEndRound - times',$times);
-		if(count($times)>0){
-			usort($times,'matchlogRecCompare');
-			$best = $times[0]['FinalTime'];
- 			$msg = '$i$s$n$dfdR-'.$_players_round_current.'$cc0>> ';
-			$msg2 = 'Round-'.$_players_round_current;
-			$sep = '';
-			$sep2 = ':';
-			for($i=0;$i<count($times);$i++){
-				if($i==0){
-					if($_GameInfos['GameMode']==2)
-						$msg2 .= '(B='.$_teams[0]['Score'].',R='.$_teams[1]['Score'].')';
-					else
-						$msg2 .= '('.MwTimeToString($times[$i]['FinalTime']).')';
-				}
-				$msg .= $sep.'$0f0 '.($i+1).'.'.$_team_color[$times[$i]['TeamId']].stripColors($times[$i]['NickName']);
-				$msg2 .= $sep2.stripColors($times[$i]['NickName']);
-				if($i<3)
-					$msg .= ' $8b8('.MwTimeToString($times[$i]['FinalTime']).')';
-				$sep = ', ';
-				$sep2 = ',';
-			}
-			$sep2 = "\nTimes: ";
-			for($i=0;$i<count($times)&&$i<10;$i++){
-				$msg2 .= $sep2.stripColors($times[$i]['Login']).'('.MwTimeToString($times[$i]['FinalTime']).')';
-				$sep2 = ', ';
-			}
-			matchlog($msg2);
-			// don't show in chat for TMU dedicated (visible in manialinks)
-			//addCall(null,'ChatSendServerMessage', $msg);
-		}
 	}
+
+	Matchlog::create("END_ROUND", $GameInfos["GameMode"], $ChallengeInfo, $Ranking);
 }
-
-// -----------------------------------
-// compare function for usort, return -1 if $a should be before $b
-function matchlogRecCompare($a, $b){
-  if($a['FinalTime']<=0 && $b['FinalTime']<=0)
-    return strcmp($a['NickName'],$b['NickName']);
-  elseif($b['FinalTime']<=0)
-    return -1;
-  elseif($a['FinalTime']<=0)
-    return 1;
-  // both best ok, so...
-  elseif($a['FinalTime']<$b['FinalTime'])
-    return -1;
-  elseif($a['FinalTime']>$b['FinalTime'])
-    return 1;
-  return -1;
-  // same best, so...
-  //elseif(isset($a['NewBest']) && isset($a['NewBest']))
-  //return ($a['NewBest']<$b['NewBest'])? -1 : 1;
-  //else
-  //return ($a['Rank']<$b['Rank'])? -1 : 1;
-}
-
-
 
 //------------------------------------------
 // RaceFinish
 //------------------------------------------
 function matchlogEndRace($event,$Ranking,$ChallengeInfo,$GameInfos){
-	global $_debug,$_players,$_PlayerList,$_Ranking,$do_match_log,$_NumberOfChecks,$_players_round_current,$_lapspoints_points,$_lapspoints_finishbonus,$_lapspoints_notfinishmultiplier,$_lapspoints_rule,$_WarmUp,$_FWarmUp,$_GameInfos,$_players_round_time,$_currentTime,$_FGameModes,$_FGameMode;
-	if(!$do_match_log || $_WarmUp || $_FWarmUp > 0)
+	if(isMatchlogDisabled() || hasFGameMode("MatchLogEndRace",$event,$Ranking,$ChallengeInfo,$GameInfos, null)) {
 		return;
-
-	if(isset($_FGameModes[$_FGameMode]['MatchLogEndRace']) && $_FGameModes[$_FGameMode]['MatchLogEndRace'] != '' &&
-		 function_exists($_FGameModes[$_FGameMode]['MatchLogEndRace'])){
-		// call FGameMode matchlog callback if exists
-		call_user_func($_FGameModes[$_FGameMode]['MatchLogEndRace'],$event,$Ranking,$ChallengeInfo,$GameInfos);
-
-		// team match log
-	}elseif($GameInfos['GameMode'] == 2){ // team
-
-		$tnick0 = ''.$Ranking[0]['NickName'];
-		$tnick1 = ''.$Ranking[1]['NickName'];
-
-		$msg = 'Score: '.$tnick0.' '.$_Ranking[0]['Score'].' <> '.$_Ranking[1]['Score'].' '.$tnick1."\n";
-		matchlog($msg);
-
-		$cuid = isset($ChallengeInfo['UId']) ? $ChallengeInfo['UId'] : 'UID';
-		$msg1 = 'TEAM MATCH on ['.stripColors($ChallengeInfo['Name']).'] ('.$ChallengeInfo['Environnement'].','.$cuid.','.stripColors($ChallengeInfo['Author']).') ['.$_players_round_current.'r]';
-		$msg1 .= "\nFinal Score: ".$tnick0.' '.$Ranking[0]['Score'].' <> '.$Ranking[1]['Score'].' '.$tnick1;
-		$sep = "\n* Blue players: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['TeamId']) && ($_PlayerList[$i]['TeamId']==0)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		$sep = "\n* Red players: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['TeamId']) && ($_PlayerList[$i]['TeamId']==1)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		$sep = "\n* Spectators: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['IsSpectator']) && ($_PlayerList[$i]['IsSpectator']==1)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		$sep = "\n* All players: ";  // server don't give player team info
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(!isset($_PlayerList[$i]['TeamId'])){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		$sep = "\n* Results: "; // pos in each round
-		foreach($_players as $login => &$pl){
-			if(!is_string($login))
-				$login = ''.$login;
-			if(count($pl['RoundsPos'])>0){
-				$rend = endkey($pl['RoundsPos']);
-				if($rend < $_players_round_current)
-					$rend = $_players_round_current;
-
-				$msg1 .= $sep.$login.'(';
-				$sep2 = '';
-				for($rnum=1; $rnum<=$rend; $rnum++){
-					if(isset($pl['RoundsPos'][$rnum]))
-						$msg1 .= $sep2.$pl['RoundsPos'][$rnum];
-					else
-						$msg1 .= $sep2.'*';
-					$sep2 = ',';
-				}
-				$msg1 .= ')';
-				$sep = ', ';
-			}
-		}
-		matchlog($msg1."\n\n");
-
-
-		// rounds match log
-	}elseif($GameInfos['GameMode'] == 0 || $GameInfos['GameMode'] == 5){ // rounds
-
-		$cuid = isset($ChallengeInfo['UId']) ? $ChallengeInfo['UId'] : 'UID';
-		$msg1 = 'ROUNDS MATCH on ['.stripColors($ChallengeInfo['Name']).'] ('.$ChallengeInfo['Environnement'].','.$cuid.','.stripColors($ChallengeInfo['Author']).') ['.$_players_round_current.'r]';
-		for($i = 0; $i < sizeof($Ranking); $i++){
-			$msg1 .= "\n".$Ranking[$i]['Rank'].','.$Ranking[$i]['Score'].','.MwTimeToString($Ranking[$i]['BestTime']).','.stripColors($Ranking[$i]['Login']).','.stripColors($Ranking[$i]['NickName']);
-		}
-		$sep = "\n* Spectators: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['IsSpectator']) && ($_PlayerList[$i]['IsSpectator'] == 1)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		$sep = "\n* Results: "; // pos in each round
-		foreach($_players as $login => &$pl){
-			if(!is_string($login))
-				$login = ''.$login;
-			if(count($pl['RoundsPos'])>0){
-				$rend = endkey($pl['RoundsPos']);
-				if($rend < $_players_round_current)
-					$rend = $_players_round_current;
-
-				$msg1 .= $sep.$login.'(';
-				$sep2 = '';
-				for($rnum=1; $rnum<=$rend; $rnum++){
-					if(isset($pl['RoundsPos'][$rnum]))
-						$msg1 .= $sep2.$pl['RoundsPos'][$rnum];
-					else
-						$msg1 .= $sep2.'*';
-					$sep2 = ',';
-				}
-				$msg1 .= ')';
-				$sep = ', ';
-			}
-		}
-		matchlog($msg1."\n\n");
-
-
-		// timeattack match log
-	}elseif($GameInfos['GameMode'] == 1){ // timeattack
-
-		$cuid = isset($ChallengeInfo['UId']) ? $ChallengeInfo['UId'] : 'UID';
-		$msg1 = 'TIMEATTACK MATCH on ['.stripColors($ChallengeInfo['Name']).'] ('.$ChallengeInfo['Environnement'].','.$cuid.','.stripColors($ChallengeInfo['Author']).')';
-		for($i = 0; $i < sizeof($Ranking); $i++){
-			$msg1 .= "\n".$Ranking[$i]['Rank'].','.MwTimeToString($Ranking[$i]['BestTime']).','.stripColors($Ranking[$i]['Login']).','.stripColors($Ranking[$i]['NickName']);
-		}
-		$sep = "\n* Spectators: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['IsSpectator']) && ($_PlayerList[$i]['IsSpectator'] == 1)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		matchlog($msg1."\n\n");
-
-
-	}elseif($GameInfos['GameMode'] == 4){ // stunts
-
-		$cuid = isset($ChallengeInfo['UId']) ? $ChallengeInfo['UId'] : 'UID';
-		$msg1 = 'STUNTS MATCH on ['.stripColors($ChallengeInfo['Name']).'] ('.$ChallengeInfo['Environnement'].','.$cuid.','.stripColors($ChallengeInfo['Author']).')';
-		for($i = 0; $i < sizeof($Ranking); $i++){
-			$msg1 .= "\n".$Ranking[$i]['Rank'].','.$Ranking[$i]['Score'].','.stripColors($Ranking[$i]['Login']).','.stripColors($Ranking[$i]['NickName']);
-		}
-		$sep = "\n* Spectators: ";
-		for($i = 0; $i < sizeof($_PlayerList); $i++){
-			if(isset($_PlayerList[$i]['IsSpectator']) && ($_PlayerList[$i]['IsSpectator'] == 1)){
-				$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-				$sep = ', ';
-			}
-		}
-		matchlog($msg1."\n\n");
-
-
-		// laps match log
-	}elseif($GameInfos['GameMode'] == 3){
-		if($_NumberOfChecks > 0){
-			// make table
-			$lasttime = 0;
-			$times = array();
-			$nbfinished = 0;
-			$mincpdelay = 99999;
-			foreach($_players as $login => &$pl){
-				if(!is_string($login))
-					$login = ''.$login;
-				if($pl['CheckpointNumber'] > 0 && $pl['LastCpTime'] > 0 && $pl['LapNumber'] >= 0){
-					//debugPrint('matchlogEndRace - players[$login]',$_players[$login]);
-					if($pl['FinalTime'] > 0)
-						$nbfinished++;
-					$times[] = array('Login'=>$login,'NickName'=>$pl['NickName'],
-													 'Check'=>$pl['CheckpointNumber']+1,
-													 'Lap'=>$pl['LapNumber'],
-													 'Time'=>$pl['LastCpTime'],
-													 'BestLap'=>$pl['BestLapTime'],
-													 'CPdelay'=>$pl['CPdelay']);
-					if($pl['LastCpTime'] > $lasttime)
-						$lasttime = $pl['LastCpTime'];
-				}else{
-					if($_debug>1) console("matchlogEndRace:: skipped: {$login},{$pl['Active']},{$pl['CheckpointNumber']},{$pl['Score']},{$pl['LapNumber']},{$pl['LastCpTime']},{$pl['BestLapTime']}");
-				}
-				if($pl['CPdelay'] > 0 && $pl['CPdelay'] < $mincpdelay)
-					$mincpdelay = $pl['CPdelay'];
-			}
-
-			$timefinished = false;
-			if($GameInfos['LapsTimeLimit'] > 0){
-				if(($_currentTime - $_players_round_time) > $GameInfos['LapsTimeLimit']){
-					console("matchlogEndRace::Laps race finished by timelimit (race time)");
-					$timefinished = true;
-				}
-				if($lasttime + 10000 > $GameInfos['LapsTimeLimit']){
-					console("matchlogEndRace::Laps race finished by timelimit (player time)");
-					$timefinished = true;
-				}
-			}
-
-			if(count($times) > 0 && ($nbfinished > 0 || $timefinished)){
-
-				// sort laps times, then make log and message
-				usort($times,'matchlogRecCompareLaps');
-				// search bestlap player
-				$bestlapi = 0;
-				for($i = 0; $i < sizeof($times); $i++){
-					if($times[$i]['BestLap']>0){
-						if($times[$bestlapi]['BestLap']<=0 || $times[$bestlapi]['BestLap']>$times[$i]['BestLap'])
-							$bestlapi = $i;
-					}
-				}
-
-				//if($_debug>8) debugPrint("matchlogEndRace - Laps - times",$times);
-				//
-				$cuid = isset($ChallengeInfo['UId']) ? $ChallengeInfo['UId'] : 'UID';
-				$msg = '$i$s$n$dfdRace$cc0>> ';
-				$msg1 = 'LAPS MATCH on ['.stripColors($ChallengeInfo['Name']).'] ('
-				.$ChallengeInfo['Environnement'].','.$cuid.','.stripColors($ChallengeInfo['Author']).')';
-				$sep = '';
-				for($i = 0; $i < sizeof($times); $i++){
-					if($i==$bestlapi){
-						$msg .= $sep.'$0f0 '.($i+1).'.$ecc'.stripColors($times[$i]['NickName'])
-						.' $aaa('.$times[$i]['Check'].','.MwTimeToString($times[$i]['Time'])
-						.',$ecc'.MwTimeToString($times[$i]['BestLap']).'$aaa)';
-					}else{
-						$msg .= $sep.'$0f0 '.($i+1).'.$ddd'.stripColors($times[$i]['NickName'])
-						.' $aaa('.$times[$i]['Check'].','.MwTimeToString($times[$i]['Time']).')';
-					}
-					$msg1 .= "\n".($i+1).','.$times[$i]['Lap'].','.$times[$i]['Check'].','
-					.MwTimeToString($times[$i]['Time']).','.MwTimeToString($times[$i]['BestLap']).','
-					.(($times[$i]['CPdelay']-$mincpdelay)/1000).',';
-
-					$lapspoints = 0;
-					// main points
-					if(isset($_lapspoints_points[$_lapspoints_rule][$i]))
-						$lapspoints += $_lapspoints_points[$_lapspoints_rule][$i];
-					else
-						$lapspoints += end($_lapspoints_points[$_lapspoints_rule]);
-
-					if($times[$i]['Check'] >= $times[0]['Check']){
-						// add finish bonus
-						if(isset($_lapspoints_finishbonus[$_lapspoints_rule]) && isset($_lapspoints_finishbonus[$_lapspoints_rule][100]))
-							$lapspoints += $_lapspoints_finishbonus[$_lapspoints_rule][100];
-
-					}else{
-						// not finished
-						if(isset($_lapspoints_notfinishmultiplier[$_lapspoints_rule])){
-							// not finished multiplier
-							$lapspoints = (int) ceil($lapspoints * $_lapspoints_notfinishmultiplier[$_lapspoints_rule]);
-
-						}elseif(isset($_lapspoints_finishbonus[$_lapspoints_rule])){
-							// or else partial race % bonuses
-							$partial = (int) floor($times[$i]['Check'] * 100 / $times[0]['Check']);
-							foreach($_lapspoints_finishbonus[$_lapspoints_rule] as $val => $bonus){
-								if($partial >= $val){
-									$lapspoints += $bonus;
-									break;
-								}
-							}
-						}
-					}
-					$msg1 .= $lapspoints.',';
-
-					$msg1 .= stripColors($times[$i]['Login']).','.stripColors($times[$i]['NickName']);
-					$sep = ', ';
-				}
-				$sep = "\n* Spectators: ";
-				for($i = 0; $i < sizeof($_PlayerList); $i++){
-					if(isset($_PlayerList[$i]['IsSpectator']) && ($_PlayerList[$i]['IsSpectator'] == 1)){
-						$msg1 .= $sep.stripColors($_PlayerList[$i]['Login']).'['.stripColors($_PlayerList[$i]['NickName']).']';
-						$sep = ', ';
-					}
-				}
-				$msg1 .= "\n* BestLap: ".MwTimeToString($times[$bestlapi]['BestLap']).','
-				.stripColors($times[$bestlapi]['Login']).','.stripColors($times[$bestlapi]['NickName']);
-				addCall(null,'ChatSendServerMessage', $msg);
-				matchlog($msg1."\n\n");
-				console("to matchlog: ".$msg1);
-			}else{
-				if($_debug>1) console("matchlogEndRace:: Not sent to matchlog:  no times or none have finished !!!");
-			}
-		}else{
-			if($_debug>1) console("matchlogEndRace:: Not sent to matchlog: _NumberOfChecks={$_NumberOfChecks} !!!");
-		}
 	}
 
+	Matchlog::create("END_RACE", $GameInfos["GameMode"], $ChallengeInfo, $Ranking);
 }
-
 
 // -----------------------------------
 function matchlogEndResult($event){
-	//console("matchlog.Event[$event]");
-	global $_debug,$do_match_log,$_matchlog_copy,$_matchlog_url,$matchfilename,$htmlmatchfilename,$_WarmUp,$_FWarmUp;
-	if(!$do_match_log || $_WarmUp || $_FWarmUp > 0)
+	global $do_match_log,$_matchlog_copy,$_matchlog_url,$matchfilename,$htmlmatchfilename,$_WarmUp,$_FWarmUp;
+	if (isMatchlogDisabled()) {
 		return;
+	}
 
 	// copy matchlog
 	if(isset($_matchlog_copy)){
@@ -481,47 +126,20 @@ function matchlogEndResult($event){
 		$datas .= '</pre></body></html>';
 		$nb = file_put_contents('fastlog/'.$htmlmatchfilename,$datas);
 
-		if($nb>100){
+		if($nb > 100){
 			// copy html matchlog
 			console("Copy fastlog/$htmlmatchfilename ($nb/".strlen($datas).")...");
 
-			if(isset($_matchlog_url))
+			if(isset($_matchlog_url)) {
 				$addcall = array(null,'ChatSendServerMessage',
-											localeText(null,'server_message').'$l['.$_matchlog_url.$htmlmatchfilename.']matchlog copied.');
-			else
+					localeText(null,'server_message').'$l['.$_matchlog_url.$htmlmatchfilename.']matchlog copied.');
+			} else {
 				$addcall = null;
+			}
 
 			file_copy('fastlog/'.$htmlmatchfilename,$_matchlog_copy.$htmlmatchfilename,$addcall);
 		}
 	}
-}
-
-
-// -----------------------------------
-// compare function for usort, return -1 if $a should be before $b
-function matchlogRecCompareLaps($a, $b)
-{
-	if($a['Check']>$b['Check'])
-		return -1;
-	elseif($a['Check']<$b['Check'])
-		return 1;
-	// same number of check, test times
-	elseif($a['Time']<$b['Time'])
-    return -1;
-  elseif($a['Time']>$b['Time'])
-    return 1;
-	// same times, test bestlap times
-  elseif($a['BestLap']<=0 && $b['BestLap']<=0)
-		return -1;
-	elseif($b['BestLap']<=0)
-		return -1;
-	elseif($a['BestLap']<=0)
-		return 1;
-	elseif($a['BestLap']<$b['BestLap'])
-		return -1;
-	elseif($a['BestLap']>$b['BestLap'])
-		return 1;
-	return -1;
 }
 
 
@@ -536,6 +154,38 @@ function matchlog($text){
 	}
 }
 
+function isMatchlogDisabled() {
+	global $do_match_log,$_WarmUp,$_FWarmUp;
+	return !$do_match_log || $_WarmUp || $_FWarmUp > 0;
+}
 
+/**
+ * Not sure what this function does.
+ *
+ * @param $fGameModeIndex
+ * @param $event
+ * @param $Ranking
+ * @param $ChallengeInfo
+ * @param $GameInfos
+ * @param $SpecialRestarting
+ * @return boolean
+ */
+function hasFGameMode($fGameModeIndex, $event, $Ranking, $ChallengeInfo, $GameInfos, $SpecialRestarting) {
+	global $_FGameModes, $_FGameMode;
+
+	if(isset($_FGameModes[$_FGameMode][$fGameModeIndex]) && $_FGameModes[$_FGameMode][$fGameModeIndex] != ''
+		&& function_exists($_FGameModes[$_FGameMode][$fGameModeIndex])){
+		// call FGameMode matchlog callback if exists
+		if (isset($SpecialRestarting)) {
+			call_user_func($_FGameModes[$_FGameMode][$fGameModeIndex],$event,$Ranking,$ChallengeInfo,$GameInfos,$SpecialRestarting);
+		} else {
+			call_user_func($_FGameModes[$_FGameMode][$fGameModeIndex],$event,$Ranking,$ChallengeInfo,$GameInfos);
+		}
+
+		return true;
+	}
+
+	return false;
+}
 
 ?>


### PR DESCRIPTION
- Best lap times in matchlog. If 24 laps is driven then 24 best laps will be logged.
- Refactoring of matchlogs-code. Now everything is split into classes and methods.  Hopefully it should help in making the code more readable and therefore more understandable.

Chat message to the players:
![image](https://user-images.githubusercontent.com/1152617/208897171-5c1704dc-bf04-4367-9390-e960d08e223e.png)

Matchlog:
![image](https://user-images.githubusercontent.com/1152617/208897297-8ba6e17a-fcd3-4fe8-9c83-60bba3ddb425.png)

 